### PR TITLE
fix generating top level TOC when minimumDepth > 1

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -130,10 +130,15 @@ export default class TableOfContentsPlugin extends Plugin {
           data.headings || [],
           cursor
         );
+        const depth = Math.max(
+          currentHeaderDepth + 1,
+          this.settings.minimumDepth
+        );
 
         return {
           ...this.settings,
-          maximumDepth: currentHeaderDepth + 1,
+          minimumDepth: depth,
+          maximumDepth: depth,
         };
       }),
     });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[main-canary.6.3a583d75ce9ad8ca733e42f16567ff2ea697f8f7.js](https://github.com/hipstersmoothie/obsidian-plugin-toc/releases/download/0.0.0-canary/main-canary.6.3a583d75ce9ad8ca733e42f16567ff2ea697f8f7.js)  
[manifest-canary.6.3a583d75ce9ad8ca733e42f16567ff2ea697f8f7.json](https://github.com/hipstersmoothie/obsidian-plugin-toc/releases/download/0.0.0-canary/manifest-canary.6.3a583d75ce9ad8ca733e42f16567ff2ea697f8f7.json)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
