### PR TITLE
Header view mask (close #8)

### DIFF
--- a/src/create-toc.ts
+++ b/src/create-toc.ts
@@ -64,11 +64,19 @@ export const createToc = (
   const firstHeadingDepth = includedHeadings[0].level;
   const links = includedHeadings.map((heading) => {
     const itemIndication = (settings.listStyle === "number" && "1.") || "-";
+	const indentText = (settings.indentText || "\t")
+		.replace("\\t", "\t");
     const indent = new Array(Math.max(0, heading.level - firstHeadingDepth))
-      .fill("\t")
+      .fill(indentText)
       .join("");
+	  
+	const view = settings.linkMask 
+      ? settings.linkMask.replace("{{indent}}", indent)
+		.replace("{{itemIndication}}", itemIndication)
+		.replace("{{heading}}", heading.heading)
+	  : `${indent}${itemIndication} [[#{heading.heading}|${heading.heading}]]`;
 
-    return `${indent}${itemIndication} [[#${heading.heading}|${heading.heading}]]`;
+    return view;
   });
 
   return endent`

--- a/src/create-toc.ts
+++ b/src/create-toc.ts
@@ -69,12 +69,17 @@ export const createToc = (
       .fill(indentText)
       .join("");
 
+    let head = heading.heading;
+    if (settings.replace !== "") {
+      head = head.replaceAll(" ", settings.replace);
+    }
+    console.log(head, settings.replace);
     const view = settings.linkMask
       ? settings.linkMask
           .replaceAll("{{indent}}", indent)
           .replaceAll("{{itemIndication}}", itemIndication)
-          .replaceAll("{{heading}}", heading.heading)
-      : `${indent}${itemIndication} [[#${heading.heading}|${heading.heading}]]`;
+          .replaceAll("{{heading}}", head)
+      : `${indent}${itemIndication} [[#${head}|${head}]]`;
 
     return view;
   });

--- a/src/create-toc.ts
+++ b/src/create-toc.ts
@@ -74,7 +74,7 @@ export const createToc = (
       ? settings.linkMask.replace("{{indent}}", indent)
 		.replace("{{itemIndication}}", itemIndication)
 		.replace("{{heading}}", heading.heading)
-	  : `${indent}${itemIndication} [[#{heading.heading}|${heading.heading}]]`;
+	  : `${indent}${itemIndication} [[#${heading.heading}|${heading.heading}]]`;
 
     return view;
   });

--- a/src/create-toc.ts
+++ b/src/create-toc.ts
@@ -64,17 +64,17 @@ export const createToc = (
   const firstHeadingDepth = includedHeadings[0].level;
   const links = includedHeadings.map((heading) => {
     const itemIndication = (settings.listStyle === "number" && "1.") || "-";
-	const indentText = (settings.indentText || "\t")
-		.replace("\\t", "\t");
+    const indentText = (settings.indentText || "\t").replace("\\t", "\t");
     const indent = new Array(Math.max(0, heading.level - firstHeadingDepth))
       .fill(indentText)
       .join("");
-	  
-	const view = settings.linkMask 
-      ? settings.linkMask.replace("{{indent}}", indent)
-		.replace("{{itemIndication}}", itemIndication)
-		.replace("{{heading}}", heading.heading)
-	  : `${indent}${itemIndication} [[#${heading.heading}|${heading.heading}]]`;
+
+    const view = settings.linkMask
+      ? settings.linkMask
+          .replaceAll("{{indent}}", indent)
+          .replaceAll("{{itemIndication}}", itemIndication)
+          .replaceAll("{{heading}}", heading.heading)
+      : `${indent}${itemIndication} [[#${heading.heading}|${heading.heading}]]`;
 
     return view;
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,47 @@ class TableOfContentsSettingsTab extends PluginSettingTab {
             this.plugin.saveData(this.plugin.settings);
           })
       );
+	  
+	new Setting(containerEl)
+      .setName("Indent text")
+      .setDesc("\\t - tabulation")
+      .addText((text) =>
+        text
+          .setPlaceholder("\\t")
+          .setValue(this.plugin.settings.indentText || "")
+          .onChange((value) => {
+            this.plugin.settings.indentText = value;
+            this.plugin.saveData(this.plugin.settings);
+          })
+      );
+
+    const linkMaskSettingItem = new Setting(containerEl)
+      .setName("Link mask")
+      .setDesc("Avaliable vars: {{indent}}, {{itemIndication}}, {{heading}}.");
+		
+	const defaultLinkMask = "{{indent}}{{itemIndication}} [[#{{heading}}]]";
+	let resetLinkMaskBtn = null;
+    linkMaskSettingItem.addText((input) =>
+        input
+          .setPlaceholder("{{indent}}{{itemIndication}} [[#{{heading}}]]")
+          .setValue(this.plugin.settings.linkMask || "")
+          .onChange((value) => {
+            this.plugin.settings.linkMask = value;
+            this.plugin.saveData(this.plugin.settings);
+			
+			if(!resetBtn){
+			  resetBtn = linkMaskSettingItem.addExtraButton((btn) => 
+				btn
+				  .setTooltip("Default")
+				  .setIcon("reset")
+				  .onClick(() => {
+					input.setValue(defaultLinkMask);		
+					this.plugin.settings.linkMask = defaultLinkMask;
+					this.plugin.saveData(this.plugin.settings);
+				}));
+			}
+          })
+      );
 
     new Setting(containerEl)
       .setName("Minimum Header Depth")
@@ -99,6 +140,8 @@ interface TableOfContentsPluginSettings {
   minimumDepth: number;
   maximumDepth: number;
   title?: string;
+  indentText?: string;
+  linkMask?: string;
 }
 
 export default class TableOfContentsPlugin extends Plugin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,9 +32,9 @@ class TableOfContentsSettingsTab extends PluginSettingTab {
       .setDesc("The type of list to render the table of contents as.")
       .addDropdown((dropdown) =>
         dropdown
-          .setValue(this.plugin.settings.listStyle)
           .addOption("bullet", "Bullet")
           .addOption("number", "Number")
+          .setValue(this.plugin.settings.listStyle)
           .onChange((value: any) => {
             this.plugin.settings.listStyle = value;
             this.plugin.saveData(this.plugin.settings);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,10 +35,9 @@ class TableOfContentsSettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.listStyle)
           .addOption("bullet", "Bullet")
           .addOption("number", "Number")
-          .onChange((value) => {
-            this.plugin.settings.listStyle = value as any;
+          .onChange((value: any) => {
+            this.plugin.settings.listStyle = value;
             this.plugin.saveData(this.plugin.settings);
-            this.display();
           })
       );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
   Setting,
 } from "obsidian";
 import { createToc, getCurrentHeaderDepth } from "./create-toc";
+import { TableOfContentsPluginSettings } from "./types";
 
 export interface CursorPosition {
   line: number;
@@ -53,8 +54,8 @@ class TableOfContentsSettingsTab extends PluginSettingTab {
             this.plugin.saveData(this.plugin.settings);
           })
       );
-	  
-	new Setting(containerEl)
+
+    new Setting(containerEl)
       .setName("Indent text")
       .setDesc("\\t - tabulation")
       .addText((text) =>
@@ -67,33 +68,47 @@ class TableOfContentsSettingsTab extends PluginSettingTab {
           })
       );
 
+    new Setting(containerEl)
+      .setName("replace title space")
+      .setDesc("replace title space with other string, such as -")
+      .addText((text) =>
+        text
+          .setPlaceholder("-")
+          .setValue(this.plugin.settings.replace || "")
+          .onChange((value) => {
+            this.plugin.settings.replace = value;
+            this.plugin.saveData(this.plugin.settings);
+          })
+      );
+
     const linkMaskSettingItem = new Setting(containerEl)
       .setName("Link mask")
       .setDesc("Avaliable vars: {{indent}}, {{itemIndication}}, {{heading}}.");
-		
-	const defaultLinkMask = "{{indent}}{{itemIndication}} [[#{{heading}}]]";
-	let resetLinkMaskBtn = null;
+
+    const defaultLinkMask = "{{indent}}{{itemIndication}} [[#{{heading}}]]";
+    let resetLinkMaskBtn = null;
     linkMaskSettingItem.addText((input) =>
-        input
-          .setPlaceholder("{{indent}}{{itemIndication}} [[#{{heading}}]]")
-          .setValue(this.plugin.settings.linkMask || "")
-          .onChange((value) => {
-            this.plugin.settings.linkMask = value;
-            this.plugin.saveData(this.plugin.settings);
-			
-			if(!resetLinkMaskBtn){
-			  resetLinkMaskBtn = linkMaskSettingItem.addExtraButton((btn) => 
-				btn
-				  .setTooltip("Default")
-				  .setIcon("reset")
-				  .onClick(() => {
-					input.setValue(defaultLinkMask);		
-					this.plugin.settings.linkMask = defaultLinkMask;
-					this.plugin.saveData(this.plugin.settings);
-				}));
-			}
-          })
-      );
+      input
+        .setPlaceholder("{{indent}}{{itemIndication}} [[#{{heading}}]]")
+        .setValue(this.plugin.settings.linkMask || "")
+        .onChange((value) => {
+          this.plugin.settings.linkMask = value;
+          this.plugin.saveData(this.plugin.settings);
+
+          if (!resetLinkMaskBtn) {
+            resetLinkMaskBtn = linkMaskSettingItem.addExtraButton((btn) =>
+              btn
+                .setTooltip("Default")
+                .setIcon("reset")
+                .onClick(() => {
+                  input.setValue(defaultLinkMask);
+                  this.plugin.settings.linkMask = defaultLinkMask;
+                  this.plugin.saveData(this.plugin.settings);
+                })
+            );
+          }
+        })
+    );
 
     new Setting(containerEl)
       .setName("Minimum Header Depth")
@@ -134,20 +149,12 @@ type GetSettings = (
   cursor: CodeMirror.Position
 ) => TableOfContentsPluginSettings;
 
-interface TableOfContentsPluginSettings {
-  listStyle: "bullet" | "number";
-  minimumDepth: number;
-  maximumDepth: number;
-  title?: string;
-  indentText?: string;
-  linkMask?: string;
-}
-
 export default class TableOfContentsPlugin extends Plugin {
   public settings: TableOfContentsPluginSettings = {
     minimumDepth: 2,
     maximumDepth: 6,
     listStyle: "bullet",
+    replace: "",
   };
 
   public async onload(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,8 +82,8 @@ class TableOfContentsSettingsTab extends PluginSettingTab {
             this.plugin.settings.linkMask = value;
             this.plugin.saveData(this.plugin.settings);
 			
-			if(!resetBtn){
-			  resetBtn = linkMaskSettingItem.addExtraButton((btn) => 
+			if(!resetLinkMaskBtn){
+			  resetLinkMaskBtn = linkMaskSettingItem.addExtraButton((btn) => 
 				btn
 				  .setTooltip("Default")
 				  .setIcon("reset")

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,5 @@ export interface TableOfContentsPluginSettings {
   title?: string;
   indentText?: string;
   linkMask?: string;
+  replace: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,6 @@ export interface TableOfContentsPluginSettings {
   minimumDepth: number;
   maximumDepth: number;
   title?: string;
+  indentText?: string;
+  linkMask?: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "lib": ["dom", "es5", "scripthost", "es2015"],
+    "lib": ["dom", "es5", "scripthost", "es2015", "es2021"],
     "strict": true
   },
   "include": ["**/*.ts"]


### PR DESCRIPTION
Some other MD editors do not support `[[#Hedaer|Some text]]` only `[[#Header]]`.
So I guess the mask will help other people too.
![plugin](https://user-images.githubusercontent.com/56083544/127338707-de3cce91-c185-4abe-98cc-8614cf956442.gif)
