### PR TITLE
maximumDepth slider bug fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ class TableOfContentsSettingsTab extends PluginSettingTab {
           .setDynamicTooltip()
           .setLimits(1, 6, 1)
           .onChange((value) => {
-            this.plugin.settings.minimumDepth = value;
+            this.plugin.settings.maximumDepth = value;
             this.plugin.saveData(this.plugin.settings);
           })
       );


### PR DESCRIPTION
Fixes bug where the value of the maximum depth slider is being assigned to minimumDepth.